### PR TITLE
Remove URI.encode(...)

### DIFF
--- a/lib/swagger_client/api_client.rb
+++ b/lib/swagger_client/api_client.rb
@@ -262,7 +262,7 @@ module SwaggerClient
     def build_request_url(path)
       # Add leading and trailing slashes to path
       path = "/#{path}".gsub(/\/+/, '/')
-      URI.encode(@config.base_url + path)
+      URI::DEFAULT_PARSER.escape(@config.base_url + path)
     end
 
     # Builds the HTTP request body

--- a/lib/swagger_client/configuration.rb
+++ b/lib/swagger_client/configuration.rb
@@ -180,7 +180,7 @@ module SwaggerClient
 
     def base_url
       url = "#{scheme}://#{[host, base_path].join('/').gsub(/\/+/, '/')}".sub(/\/+\z/, '')
-      URI.encode(url)
+      URI::DEFAULT_PARSER.escape(url)
     end
 
     # Gets API key (with prefix if set).


### PR DESCRIPTION
Use URI::DEFAULT_PARSER.escape(...) instead